### PR TITLE
修正获取JSON对象字段行为错误的问题以修正验证令牌鉴权问题

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -19,5 +19,9 @@ pub fn parse_response(response: &str) -> Result<Value, serde_json::Error> {
 
 #[inline]
 pub fn fetch_value(json_text: Value, key: &str) -> Option<String> {
-    Some(json_text.get(key)?.to_string())
+    if let Some(Value::String(val)) = json_text.get(key) {
+        Some(val.to_owned())
+    } else {
+        None
+    }
 }


### PR DESCRIPTION
简单看了一遍代码，定位了问题在于你获取 JSON 对象中的字符串值出现了问题。

`serde_json::Value::get` 用于获取对象中的指定字段的**任意类型对象**，所以其返回值是 `Option<&serde_json::Value>`。因此你在 `gridcore::json::fetch_value` 中实际上是调用了 `serde_json::Value` 所实现的 `Display` 特质的转字符串功能，而其实现会保持 JSON 的格式转换成字符串（类似于你在 JS 中给给 `JSON.stringify` 传入纯字符串一样），所以你所获取到的实际值字符串会被打上双引号（例如 `"\"token\""` 而不是 `"token"`）或者多出其他可能的转义字符。进而导致了传参和鉴权失败。

能看到使用 Rust 编写 Minecraft 启动器代码的人不多见，所以请作者多多加油，可以参考我的[ SharpCraftLauncher 启动器核心的微软登录相关模块](https://github.com/Steve-xmh/scl/tree/main/scl-core/src/auth/microsoft)继续完成代码哦！~~（虽然依然是屎山代码）~~

参考链接：
- https://docs.rs/serde_json/latest/serde_json/enum.Value.html#method.get